### PR TITLE
change tf.distribute.resolver to tf.distribute.cluster_resolver

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -179,7 +179,7 @@ TPU devices:
 在 TPU 上进行 TensorFlow 分布式训练的核心API是`tf.distribute.TPUStrategy`，可以简单几行代码就实现在 TPU 上的分布式训练，同时也可以很容易的迁移到 GPU单机多卡、多机多卡的环境。以下是如何实例化 `TPUStrategy`：
 
 ```python
-resolver = tf.distribute.resolver.TPUClusterResolver(
+resolver = tf.distribute.cluster_resolver.TPUClusterResolver(
     tpu='grpc://' + os.environ['COLAB_TPU_ADDR'])
 tf.config.experimental_connect_to_host(resolver.master())
 tf.tpu.experimental.initialize_tpu_system(resolver)
@@ -216,7 +216,7 @@ def create_model():
   
   return model
 
-resolver = tf.distribute.resolver.TPUClusterResolver(
+resolver = tf.distribute.cluster_resolver.TPUClusterResolver(
     tpu='grpc://' + os.environ['COLAB_TPU_ADDR'])
 tf.config.experimental_connect_to_host(resolver.master())
 tf.tpu.experimental.initialize_tpu_system(resolver)


### PR DESCRIPTION
I found mismatch between online [doc](https://github.com/huan/tensorflow-handbook-tpu) with the example [colab](https://colab.research.google.com/github/huan/tensorflow-handbook-tpu/blob/master/tensorflow-handbook-tpu-example.ipynb), refer to issue #2 .

I have tested it for tf2.0, so maybe `tf.distribute.resolver.TPUClusterResolver` just a small typo, or there exist something else I have not taken into account.

Feel free to merge this pr to change `tf.distribute.resolver.TPUClusterResolver` to `tf.distribute.cluster_resolver.TPUClusterResolver` in the `README.md`.